### PR TITLE
Base I/O of header

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "xyBnG"
 uuid = "056de5cc-3822-4b22-85ae-bc65d3fbfd0e"
 authors = ["Xijiang Yu <xijiang@users.noreply.github.com> and contributors"]
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 CompatHelperLocal = "5224ae11-6099-4aaa-941d-3aab004bd678"

--- a/src/brd/select.jl
+++ b/src/brd/select.jl
@@ -118,7 +118,7 @@ function Select(
     @debug "Optimal contribution selection"
     dat = select(ped[ID, :], "ebv_$(trt.name)" => :idx, :sex)
 
-    K = konstraint(dF, F0, igrt)
+    K = 2(1 - (1 - F0) * (1 - dF)^igrt) #konstraint(dF, F0, igrt)
     c = ocs(dat, rs, K)  # this is to select the highest, or equivalently rev = true
     cs = ped.sex[ID] .== 1 # sire candidates
     cd = ped.sex[ID] .== 0 # dam candidates

--- a/src/fdr/sample.jl
+++ b/src/fdr/sample.jl
@@ -1,4 +1,3 @@
-
 """
     norm_v(Q::AbstractMatrix, v; ϵ = 1e-6, μ=0., σ=1.)
 

--- a/src/fxy/header.jl
+++ b/src/fxy/header.jl
@@ -23,7 +23,7 @@ function header(xy::AbstractString)
     sz = filesize(xy)
     sz ≤ 24 && return nothing
     hdr = header()
-    read!(xy, Ref(hdr))
+    read!(xy, hdr)
     (
         hdr.x == Int8('x') &&
         hdr.y == Int8('y') &&
@@ -46,6 +46,6 @@ Update header of file `xy`
 """
 function header!(xy::AbstractString, hdr::header)
     open(xy, "r+") do io
-        write(io, Ref(hdr))
+        write(io, hdr)
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -287,4 +287,25 @@ function Base.show(io::IO, h::header)
     println(io, "   Element type: $(_type(h.type))")
 end
 
+"""
+    Base.write(io::IO, h::header)
+This is for Julia v1.11+. The write and read! function was not working as
+before.
+"""
+function Base.write(io::IO, h::header)
+    v = [h.x, h.y, h.v, h.flus, h.major, h.type, h.r, h.u]
+    write(io, v)
+end
+
+"""
+    Base.write(io::IO, h::header)
+This is for Julia v1.11+. The write and read! function was not working as
+before.
+"""
+function Base.read!(io::IO, h::header)
+    v = Vector{Int8}(undef, 8)
+    read!(io, v)
+    h.x, h.y, h.v, h.flus, h.major, h.type, h.r, h.u = v
+end
+
 end # module xyTypes


### PR DESCRIPTION
These functions worked before Julia 1.11. Two Base function
- write(io, header)
- read!(io, header)

were added into xyType.